### PR TITLE
OrgLimits

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This extension helps you get to any Salesforce page quickly. Just type in what you need to do!
 
-##Commands
+## Commands
 
 #### Refresh Metadata
 Syntax: `Refresh Metadata` **(Classic Only)**
@@ -36,7 +36,7 @@ This will navigate to the profile of the System Administrator.  In this case, it
 
 ------------
 
-- ** sys prop doc man upload**
+- **sys prop doc man upload**
 
 This will navigate to the nFORCE System Property that controls the upload limit for docman. 
 The fully qualified command will look like this: `Setup > System Property (nFORCE) > document manager > upload mb limit`

--- a/README.md
+++ b/README.md
@@ -1,41 +1,238 @@
 # Lightning Navigator
 
-This extension helps you get to any Salesforce page quickly. Just type in what you need to do.
+This extension helps you get to any Salesforce page quickly. Just type in what you need to do!
 
-- All objects list views and create new pages are available (even for objects that don't have tabs). Type in "List <Object Name>" or "New <Object Name>"
+##Commands
 
-- All setup links are available -- Type in "Setup" to see all. For example, if you want to get to the Account fields setup, type in "Account Fields". Or any custom object setup page, type "setup <Custom Object Name>"
+#### Refresh Metadata
+Syntax: `Refresh Metadata` **(Classic Only)**
 
-- Thanks to the SF tooling API, you can now create fields. "cf Account newField TEXT 100."
+Forces the extension to retrieve metadata from the Salesforce org. Use this if you see that commands aren't populating in the extension.
 
-- The original Salesforce Navigator was seemingly abandoned. I added the little bit needed to support Lightning. I renamed it to prevent confusion on the Chrome Store, and as I maintain the project moving forward.
+------------
 
-- Run "Refresh Metadata" from Lightning Navigator in Salesforce Classic. From that point you can navigate and use the extenion from Lightning.
+#### Setup 
+Syntax: `Setup`
+As a standalone command, this acts as a navigational shortcut to Setup.
 
-## New features added this version
+------------
 
-- Type in "orglimits" and press enter to see the current Org Limits displayed below in a scrollable list. Delete "orglimits" to return to using Lightning Navigator normally.
+#### General Navigation
+Syntax: `Setup <Category> <Subcategory/Key> <Destination>`
 
-- Added navigation to the following by name: Apex Classes, Apex Triggers, Apex Pages, Users, Profiles, VisualForce Pages, VisualForce Components, Flows
+Any of the four components to this command are optional, and do not require entire words. Think of this as executing a large search against an index of locations. The more specific you are with your search words, the more accurate the results will be.
 
-- Added navigation to nForce and LLC_BI System Properties by Category and Key (eg: Setup > System Property (nFORCE) > document manager > archive_browser_visible)
+***This is not limited to custom objects.  The following are also searcable: Apex Classes, Apex Triggers, VisualForce Pages, VisualForce Components, Profiles, Users, Custom Settings, Flows, and Custom Labels. ***
 
-## Bug Fixes and Other Cleanup
+***Custom Settings are searchable by Category and/or Key.
+Custom Labels are searchable by Category and Name, and by Category and Value.
+All others listed are searchable by Name only at this time.***
 
-- Refresh Metadata won't glitch out on VF pages causing the extension to fill up with "undefined"
+Here are two examples:
 
-- Refresh Metadata also elegantly fails in Lightning now, rather than showing a loading indicator for a minute then doing nothing.
+- **setup Profile System Administrator**
 
-- Cleaned up some DOM interaction with appendChild/removeChild calls being mishandled
+This will navigate to the profile of the System Administrator.  In this case, it would be faster to just enter `System Administrator` and find `Setup > Profile > System Administrator` on the list of matching commands.
 
-- Cleaned up some spacing and casing stuff that bugged me
+------------
 
-## Getting Started
+- ** sys prop doc man upload**
+
+This will navigate to the nFORCE System Property that controls the upload limit for docman. 
+The fully qualified command will look like this: `Setup > System Property (nFORCE) > document manager > upload mb limit`
+
+------------
+
+#### Lists
+Syntax: `List <Object/Custom Object>`
+
+- **List AccountDocuments**
+
+Takes the user to a list view for any object type, even those without tabs. This command is also compatible with things like Apex Classes, Visualforce Components, Jobs, Logs, pretty much anything you can get to from setup. Play around with it!
+
+------------
+
+#### New
+Syntax: `New <Object/Custom Object>`
+
+- **New Collateral**
+
+Takes the user to the create page for any object type, again, even those without tabs. Much like list, this works with just about anything. If used from Lightning, it may take the user back to Classic on the way to the creation page.
+
+------------
+
+#### Organization Limits 
+Syntax: `OrgLimits` **(Classic Only)**
+
+This shows at a glance statistics of your organizational limits along with remaining values.
+[![org](https://i.imgur.com/kkeKa2p.png "org")](https://i.imgur.com/kkeKa2p.png "org")
+
+------------
+
+#### Create Field
+Usage: `cf`
+
+The cf (create field) command can be used in conjunction with an object API name like `Account`, a name for a new field, a type like `TEXT`, along with any necessary parameters depending on type, to create a new field on that object.
+
+Usage: `cf <Object API Name> <Field Name> <Data Type>`
+
+Data Type Syntax and Examples:
+
+------------
+
+- `AUTONUMBER`
+
+**cf Account TestAutonumber AUTONUMBER**
+
+------------
+
+- `CHECKBOX`
+
+**cf Account TestCheckbox CHECKBOX**
+
+------------
+
+- `CURRENCY <Scale> <Precision>`
+
+**cf Account TestCurrency CURRENCY 8 2**
+
+------------
+
+- `DATE`
+
+**cf Account TestDate DATE**
+
+------------
+
+- `DATETIME`
+
+**cf Account TestDateTime DATETIME**
+
+------------
+
+- `EMAIL`
+
+**cf Account TestEmail EMAIL**
+
+------------
+
+- `GEOLOCATION <Scale>`
+
+**cf Account TestGPS GEOLOCATION 5**
+
+------------
+
+- `LOOKUP <sObject API Name>`
+
+**cf Account TestLookupLoan LOOKUP Opportunity**
+
+(When using custom objects, full API names must be used)
+
+------------
+
+- `NUMBER <Scale> <Precision>`
+
+**cf Account TestNumber NUMBER 8 2**
+
+------------
+
+- `PERCENT <Scale> <Precision>`
+
+**cf Account TestPercent PERCENT 3 2**
+
+------------
+
+- `PHONE`
+
+**cf Account TestPhone PHONE**
+
+------------
+
+- `PICKLIST`
+
+**cf Account TestPicklist PICKLIST**
+
+(The picklist will have a filler value and will need to be changed)
+
+------------
+
+- `PICKLISTMS`
+
+**cf Account TestMultiSelectPicklist PICKLISTMS**
+
+(The picklist will have a filler value and will need to be changed)
+
+------------
+
+- `TEXT <Length>`
+
+**cf Account TestText TEXT 40**
+
+------------
+
+- `TEXTAREA`
+
+**cf Account TestTextArea TEXTAREA**
+
+------------
+
+- `TEXTAREALONG <Length> <Visible Lines>`
+
+**cf Account TestTextAreaLong TEXTAREALONG 256 5**
+
+(Minimum length of 256)
+
+------------
+
+- `TEXTAREARICH <Length> <Visible Lines>`
+
+**cf Account TestTextAreaRich TEXTAREARICH 256 10**
+
+(Minimum length of 256, minimum visible lines of 10)
+
+------------
+
+- `URL`
+
+**cf Account TestURL URL**
+
+------------
+
+## Patch Notes
+
+### 0.2.1
+
+- Fixed bug where the modal would vanish when clicking the `OrgLimits` command, making the results impossible to read.
+- `OrgLimits` properly clears out the search bar after executing the command.
+- `OrgLimits` will throw an error in Lightning and VisualForce, rather than churn and do nothing.
+- Fixed bug with precision not being passed properly by forceTooling when attempting to create certain field types.
+- Fixed bug where creating a new `TEXTAREALONG` or `TEXTAREARICH` would use the character count for the number of visible lines.
+- Corrected help text typo on `TEXTAREA` creation.
+- Added details for commands to this lovely Readme.
+
+### 0.2.0
+- Added navigation to Custom Labels by Category > Name OR by Category > Value. This is a lot of data to load so please be patient on orgs that approach that 10,000 label mark. It takes a second to append all the information.
+- Minor code formatting fixes and domain addressing cleanup.
+
+### 0.1.1
+ - Type in `OrgLimits` and press enter to see the current Org Limits displayed below in a scrollable list. Delete `OrgLimits` to return to using Lightning Navigator normally.
+ - Added navigation to the following by name: Apex Classes, Apex Triggers, Apex Pages, Users, Profiles, VisualForce Pages, VisualForce Components, Flows
+ - Added navigation to nForce and LLC_BI System Properties by Category and Key (eg: Setup > System Property (nFORCE) > document manager > archive_browser_visible)
+
+ - Refresh Metadata won't glitch out on VF pages causing the extension to fill up with "undefined"
+ - Refresh Metadata also elgeantly fails in Lightning now, rather than showing a loading indicator for a minute then doing nothing.
+ - Cleaned up some DOM interaction with appendChild/removeChild calls being mishandled
+
+------------
+
+## For Devs
+
+### Getting Started
 Project was scaffolded using [Yeoman](http://yeoman.io/) using [generator-chrome-extension](https://github.com/yeoman/generator-chrome-extension)
 
-## Test
+### Test
 To test, go to: chrome://extensions, enable Developer mode and load app as an unpacked extension.
 
-## License
+### License
 [MIT License](http://en.wikipedia.org/wiki/MIT_License)
 

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Lightning Navigator",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "manifest_version": 2,
     "default_locale": "en",
     "browser_action": {

--- a/app/scripts/forceTooling.js
+++ b/app/scripts/forceTooling.js
@@ -81,7 +81,7 @@ if (forceTooling.CustomFields === undefined) {
     this.type = type;
     this.inlineHelpText = helpText;
     this.length = parseInt(length);
-    if(this.precision != null) this.precision = parseInt(leftDecimals + rightDecimals);
+    if(leftDecimals != null && rightDecimals != null) this.precision = parseInt(leftDecimals + rightDecimals);
     this.scale = rightDecimals;
     if(picklistValues !== null)
     {
@@ -400,21 +400,21 @@ if (forceTooling.Client === undefined) {
   };
 
   // queryFieldsByName
-  forceTooling.Client.prototype.queryFieldsByName = function(name, callback, error) {
-    var queryString = forceTooling.CustomFields.queryString + ' WHERE Fullname=\'' + name + '\'';
-    return forceTooling.Client.prototype.query(this.queryString,callback,error);
+  forceTooling.Client.prototype.queryFieldsByName = function(name, objectName, callback, error) {
+    var queryString = forceTooling.CustomFields.queryString + ' WHERE DeveloperName=\'' + name + '\' AND TableEnumOrId=\'' + objectName + '\'';
+    return forceTooling.Client.prototype.query(queryString,callback,error);
   };
 
   // queryFieldsById
   forceTooling.Client.prototype.queryFieldsById = function(id, callback, error) {
     var queryString = forceTooling.CustomFields.queryString + ' WHERE Id=\'' + id + '\'';
-    return forceTooling.Client.prototype.query(this.queryString,callback,error);
+    return forceTooling.Client.prototype.query(queryString,callback,error);
   };
 
   // queryFieldsForObject
   forceTooling.Client.prototype.queryFieldsForObject = function(objectName, callback, error) {
     var queryString = forceTooling.CustomFields.queryString + ' WHERE TableEnumOrId=\'' + objectName + '\'';
-    return forceTooling.Client.prototype.query(this.queryString,callback,error);
+    return forceTooling.Client.prototype.query(queryString,callback,error);
   };
 
   // queryLogsById
@@ -425,7 +425,7 @@ if (forceTooling.Client === undefined) {
   // queryLogsById
   forceTooling.Client.prototype.queryLogsByUserId = function(userId, callback, error) {
     var queryString = forceTooling.ApexLogs.queryString + ' WHERE LogUserId=\'' + userId + '\'';
-    return forceTooling.Client.prototype.query(this.queryString,callback,error);
+    return forceTooling.Client.prototype.query(queryString,callback,error);
   };
 
   // queryLogBodyByLogId

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -107,8 +107,13 @@ var sfnav = (function() {
       setVisible("hidden");
       posi = -1;
       oldins = this.firstChild.nodeValue;
-      setVisibleSearch("hidden");
-      setVisible("hidden");
+      if (oldins == 'OrgLimits') {
+        setVisibleSearch("visible");
+        setVisible("visible");
+      } else {
+        setVisibleSearch("hidden");
+        setVisible("hidden");
+      }
       invokeCommand(this.firstChild.nodeValue,false,'click');
       clearOutput();
       searchBar.value = '';
@@ -215,7 +220,7 @@ var sfnav = (function() {
 
               break;
               case 'TEXTAREA':
-              words2.push(wordArray[0] + ' ' + wordArray[1] + ' ' + wordArray[2] + ' ' + words[i] + ' <length>');
+              words2.push(wordArray[0] + ' ' + wordArray[1] + ' ' + wordArray[2] + ' ' + words[i]);
               break;
               case 'TEXTAREALONG':
               words2.push(wordArray[0] + ' ' + wordArray[1] + ' ' + wordArray[2] + ' ' + words[i] + ' <length> <visible lines>');
@@ -516,69 +521,23 @@ var sfnav = (function() {
         loginAs(cmd);
         return true;
       }
-    if (cmd.toLowerCase().substring(0,9) == 'orglimits')
+    if (cmd.toLowerCase() == 'orglimits')
       {
+        if (location.origin.indexOf("visual.force") !== -1) {
+          document.getElementById('sfnav_quickSearch').value = 'Retrieval failed: Inside VisualForce, try from Setup';
+          clearOutput();
+          return;
+        } else if (location.origin.indexOf('lightning.force') !== -1) {
+          document.getElementById('sfnav_quickSearch').value = 'Retrieval failed: In Lightning Experience, try from Classic';
+          clearOutput();
+          return;
+        } else {
+          document.getElementById('sfnav_quickSearch').value = '';
+        }
         getLimits();
         return true;
       }
-
     return false;
-  }
-
-  function updateField(cmd)
-  {
-    var arrSplit = cmd.split(' ');
-    var dataType = '';
-    var fieldMetadata;
-
-    if (arrSplit.length >= 3)
-      {
-        for (var key in META_DATATYPES)
-          {
-            if (META_DATATYPES[key].name.toLowerCase() === arrSplit[3].toLowerCase())
-              {
-                dataType = META_DATATYPES[key].name;
-                break;
-              }
-          }
-
-        var sObjectName = arrSplit[1];
-        var fieldName = arrSplit[2];
-        var helpText = null;
-        var typeLength = arrSplit[4];
-        var rightDecimals, leftDecimals;
-        if (parseInt(arrSplit[5]) != NaN )
-          {
-            rightDecimals = parseInt(arrSplit[5]);
-            leftDecimals = typeLength;
-          }
-        else
-          {
-            leftDecimals = 0;
-            rightDecimals = 0;
-          }
-
-        ftClient.queryByName('CustomField', fieldName, sObjectName, function(success) {
-          addSuccess(success);
-          fieldMeta = new  forceTooling.CustomFields.CustomField(arrSplit[1], arrSplit[2], dataType, null, arrSplit[4], parseInt(leftDecimals),parseInt(rightDecimals),null);
-
-          ftClient.update('CustomField', fieldMeta,
-            function(success) {
-              console.log(success);
-              addSuccess(success);
-            },
-            function(error) {
-              console.log(error);
-              addError(error.responseJSON);
-            });
-        },
-          function(error)
-          {
-            addError(error.responseJSON);
-          });
-
-
-      }
   }
 
   function createField(cmd)
@@ -589,17 +548,6 @@ var sfnav = (function() {
 
     if (arrSplit.length >= 3)
       {
-        //  forceTooling.Client.create(whatever)
-        /*
-           for (var key in META_DATATYPES)
-           {
-           if (META_DATATYPES[key].name.toLowerCase() === arrSplit[3].toLowerCase())
-           {
-           dataType = META_DATATYPES[key].name;
-           break;
-           }
-           }
-         */
         dataType = META_DATATYPES[arrSplit[3].toUpperCase()].name;
         var sObjectName = arrSplit[1];
         var sObjectId = null;
@@ -689,13 +637,13 @@ var sfnav = (function() {
           fieldMeta = new  forceTooling.CustomFields.CustomField(sObjectName, sObjectId, fieldName, dataType, null, null, null,null,null,null,null);
           break;
           case 'TEXTAREA':
-          fieldMeta = new  forceTooling.CustomFields.CustomField(sObjectName, sObjectId, fieldName, dataType, null, typeLength, null,null,null,null,null);
+          fieldMeta = new  forceTooling.CustomFields.CustomField(sObjectName, sObjectId, fieldName, dataType, null, null, null,null,null,null,null);
           break;
           case 'TEXTAREALONG':
-          fieldMeta = new  forceTooling.CustomFields.CustomField(sObjectName, sObjectId, fieldName, dataType, null, typeLength, null,null,null,null,arrSplit[4]);
+          fieldMeta = new  forceTooling.CustomFields.CustomField(sObjectName, sObjectId, fieldName, dataType, null, typeLength, null,null,null,null,arrSplit[5]);
           break;
           case 'TEXTAREARICH':
-          fieldMeta = new  forceTooling.CustomFields.CustomField(sObjectName, sObjectId, fieldName, dataType, null, typeLength, null,null,null,null,arrSplit[4]);
+          fieldMeta = new  forceTooling.CustomFields.CustomField(sObjectName, sObjectId, fieldName, dataType, null, typeLength, null,null,null,null,arrSplit[5]);
           break;
           case 'URL':
           fieldMeta = new  forceTooling.CustomFields.CustomField(sObjectName, sObjectId, fieldName, dataType, null, null, null,null,null,null,null);


### PR DESCRIPTION
- Fixed bug where the modal would vanish when clicking the `OrgLimits` command, making the results impossible to read.
- `OrgLimits` properly clears out the search bar after executing the command.
- `OrgLimits` will throw an error in Lightning and VisualForce, rather than churn and do nothing.
- Fixed bug with precision not being passed properly by forceTooling when attempting to create certain field types.
- Fixed bug where creating a new `TEXTAREALONG` or `TEXTAREARICH` would use the character count for the number of visible lines.
- Corrected help text typo on `TEXTAREA` creation.
- Added details for commands to this lovely Readme.